### PR TITLE
Fix the DOI button link in the README document

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The materials are divided into two major groups:
 - session 1 - focusing on the FAIR-by-Design development of training materials starting from the prepare and design stages and moving on to produce. This session is aimed mostly for instructional designers.
 - session 2 - focusing on the FAIR-by-Design publishing, verification and continuous improvement stages. This session is aimed mostly for training workflow and infrastructure managers
 
-[![image](https://github.com/FAIR-by-Design-Methodology/IDCC24workshop/assets/58505801/d3df9e94-b204-4d9b-ad52-677996e3e8c0)](10.5281/zenodo.10676532)
+[![image](https://github.com/FAIR-by-Design-Methodology/IDCC24workshop/assets/58505801/d3df9e94-b204-4d9b-ad52-677996e3e8c0)](https://doi.org/10.5281/zenodo.10676532)
 
 
 ## How to use these materials?


### PR DESCRIPTION
The link target was not an absolute URL and therefore did not function as a link to the zenodo record. I hadded the DOI resolver prefix and this fixes it.